### PR TITLE
Fix for Issue #82

### DIFF
--- a/lib/local/platform/windows.js
+++ b/lib/local/platform/windows.js
@@ -88,7 +88,7 @@ function getEdgeDirectory() {
 
   try {
     var edgeFolders = fs.readdirSync(systemApps).filter(function(folder) {
-      return folder.startsWith('Microsoft.MicrosoftEdge');
+      return folder.indexOf('Microsoft.MicrosoftEdge') === 0;
     }).map(function(folder) {
       return path.join(systemApps, folder);
     });

--- a/lib/local/platform/windows.js
+++ b/lib/local/platform/windows.js
@@ -93,7 +93,7 @@ function getEdgeDirectory() {
       return path.join(systemApps, folder);
     });
 
-    return edgeFolders.length ? edgeFolders[0] : systemApps;
+    return edgeFolders[0] || systemApps;
   } catch(ex) {
     return systemApps;
   }

--- a/lib/local/platform/windows.js
+++ b/lib/local/platform/windows.js
@@ -87,11 +87,13 @@ function getEdgeDirectory() {
   var systemApps = path.join(windowsDirectory, 'SystemApps');
 
   try {
-    return fs.readdirSync(systemApps).filter(function(folder) {
-        return folder.startsWith('Microsoft.MicrosoftEdge');
-      }).map(function(folder) {
-        return path.join(systemApps, folder);
-      })[0];
+    var edgeFolders = fs.readdirSync(systemApps).filter(function(folder) {
+      return folder.startsWith('Microsoft.MicrosoftEdge');
+    }).map(function(folder) {
+      return path.join(systemApps, folder);
+    });
+
+    return edgeFolders.length ? edgeFolders[0] : systemApps;
   } catch(ex) {
     return systemApps;
   }


### PR DESCRIPTION
**getEdgeDirectory()** fixed to return default _systemApps_ folder instead of "undefined" in case if there is no Edge browser in the system.

"undefined" value makes subsequent call to **path.join(getEdgeDirectory(), 'MicrosoftEdge.exe')** to throw an exception.