### PR TITLE
Fixed undefined value returned by getEdgeDirectory function in Windows Server

### DIFF
--- a/lib/local/index.js
+++ b/lib/local/index.js
@@ -56,8 +56,28 @@ module.exports = function (settings, callback) {
     }).nodeify(callback);
   };
 
+  api.customBrowsers = function(custombrowsers, callback) {
+    let allowedPlatforms = {};
+    if (custombrowsers && custombrowsers.length > 0) {
+      const platformNames = Object.keys(platform);
+
+      custombrowsers.forEach(name => {
+        if (platformNames.indexOf(name) !== -1) {
+          allowedPlatforms[name] = platform[name];
+        }
+      });
+    } else {
+      allowedPlatforms = platform;
+    }
+    _getPlatforms(allowedPlatforms, callback);
+  };
+
   api.browsers = function(callback) {
-    var deferreds = _.map(platform, function(browser, name) {
+      _getPlatforms(platform, callback);
+  };
+
+  _getPlatforms = function(platforms, callback) {
+    var deferreds = _.map(platforms, function(browser, name) {
       return getBrowser(_.extend({ name: name }, browser)).then(getVersion);
     });
 

--- a/lib/local/index.js
+++ b/lib/local/index.js
@@ -57,11 +57,11 @@ module.exports = function (settings, callback) {
   };
 
   api.customBrowsers = function(custombrowsers, callback) {
-    let allowedPlatforms = {};
+    var allowedPlatforms = {};
     if (custombrowsers && custombrowsers.length > 0) {
-      const platformNames = Object.keys(platform);
+      var platformNames = Object.keys(platform);
 
-      custombrowsers.forEach(name => {
+      custombrowsers.forEach(function(name) {
         if (platformNames.indexOf(name) !== -1) {
           allowedPlatforms[name] = platform[name];
         }
@@ -76,7 +76,7 @@ module.exports = function (settings, callback) {
       _getPlatforms(platform, callback);
   };
 
-  _getPlatforms = function(platforms, callback) {
+  function _getPlatforms(platforms, callback) {
     var deferreds = _.map(platforms, function(browser, name) {
       return getBrowser(_.extend({ name: name }, browser)).then(getVersion);
     });
@@ -85,7 +85,7 @@ module.exports = function (settings, callback) {
       debug('Listed all browsers (before normalization)', browsers);
       return _.map(_.compact(browsers), normalize);
     }).nodeify(callback);
-  };
+  }
 
   _.each(platform, function(browser, name) {
     api[name] = function(url, options, callback) {

--- a/lib/local/platform/windows.js
+++ b/lib/local/platform/windows.js
@@ -38,7 +38,7 @@ module.exports = {
     cwd: cwd
   },
   edge: {
-    defaultLocation: path.join(getEdgeDirectory(), 'MicrosoftEdge.exe'),
+    defaultLocation: path.join(getEdgeDirectory() || programFiles, 'MicrosoftEdge.exe'),
     getCommand: function(browser, url) {
       return 'start /wait microsoft-edge:' + url;
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "launchpad",
   "description": "You can launch browsers! From NodeJS! Local ones! Remote ones! Browserstack ones!",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "homepage": "https://github.com/bitovi/launchpad",
   "author": [
     {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "launchpad",
   "description": "You can launch browsers! From NodeJS! Local ones! Remote ones! Browserstack ones!",
-  "version": "0.7.1",
+  "version": "0.7.0",
   "homepage": "https://github.com/bitovi/launchpad",
   "author": [
     {


### PR DESCRIPTION
@ifisidro and me are developing a CI system into a Windows server machine, and Windows Server 2016 does not have Microsoft Edge installed by default, so the function getEdgeDirectory allocated into _windows.js_ file returns undefined and after that, path.join function fails.