### PR TITLE
Added fix for failing to locate Edge on some edition of Win 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,16 +1,19 @@
 {
   "name": "launchpad",
   "description": "You can launch browsers! From NodeJS! Local ones! Remote ones! Browserstack ones!",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "homepage": "https://github.com/ekryski/launchpad",
-  "author": [{
-    "name": "Eric Kryski",
-    "email": "e.kryski@gmail.com",
-    "web": "http://erickryski.com"
-  }, {
-    "name": "David Luecke",
-    "email": "daff@neyeon.com"
-  }],
+  "author": [
+    {
+      "name": "Eric Kryski",
+      "email": "e.kryski@gmail.com",
+      "web": "http://erickryski.com"
+    },
+    {
+      "name": "David Luecke",
+      "email": "daff@neyeon.com"
+    }
+  ],
   "repository": {
     "type": "git",
     "url": "git@github.com:ekryski/launchpad.git"


### PR DESCRIPTION
Searching for Edge when it is not installed by default on Windows 10 (on LTSB ed) & Windows Server 2016 generates an error. https://en.wikipedia.org/wiki/Windows_10_editions