### PR TITLE
Fix chrome and edge directories on windows

### DIFF
--- a/lib/local/platform/windows.js
+++ b/lib/local/platform/windows.js
@@ -1,7 +1,9 @@
 var os = require('os');
 var fs = require('fs');
 var path = require('path');
-var programFiles = os.arch() === "x64" ? process.env["ProgramFiles(x86)"] : process.env.ProgramFiles;
+//Windows 64bits "Program Files"
+//Windows 32bits "Program Files x86"
+var programFiles = os.arch() === "x64" ? process.env.ProgramFiles : process.env["ProgramFiles(x86)"];
 var cwd = path.normalize(programFiles);
 var appData = appData || process.env.APPDATA;
 
@@ -22,7 +24,7 @@ module.exports = {
     opensTab: true
   },
   aurora: {
-    defaultLocation: path.join(programFiles, 'Aurora', 'firefox.exe'),
+    defaultLocation: path.join(programFiles, 'firefox.exe'),
     opensTab: true
   },
   opera: {
@@ -38,7 +40,7 @@ module.exports = {
     cwd: cwd
   },
   edge: {
-    defaultLocation: path.join(getEdgeDirectory(), 'MicrosoftEdge.exe'),
+    defaultLocation: path.join(getEdgeDirectory() || programFiles, 'MicrosoftEdge.exe'),
     getCommand: function(browser, url) {
       return 'start /wait microsoft-edge:' + url;
     },
@@ -46,7 +48,7 @@ module.exports = {
     cwd: cwd
   },
   electron: {
-    defaultLocation: path.join(process.cwd(), 'node_modules', '.bin', 'electron'),
+    defaultLocation: path.join(process.cwd(), 'node_modules', '.bin', 'electron.cmd'),
     pathQuery: 'dir /s /b electron.exe',
     args: [path.join(__dirname, '..', '..', '..', 'resources', 'electron.js')],
     multi: true,
@@ -76,10 +78,17 @@ module.exports = {
 
 function altPaths() {
   var args = Array.prototype.slice.call(arguments);
-  return [
+  var paths = [
     path.join.apply(path, [programFiles].concat(args)),
     path.join.apply(path, [appData].concat(args))
   ];
+  //chrome installed under "Program Files x86"
+  //even for x64 architecture at least for Win10
+  //the installer could be x32?
+  if (os.arch() === "x64") {
+    paths.push(path.join.apply(path, [process.env["ProgramFiles(x86)"]].concat(args)));
+  }
+  return paths;
 }
 
 function getEdgeDirectory() {
@@ -88,7 +97,9 @@ function getEdgeDirectory() {
 
   try {
     var edgeFolders = fs.readdirSync(systemApps).filter(function(folder) {
-      return folder.indexOf('Microsoft.MicrosoftEdge') === 0;
+      // Windows 10 has Microsoft.MicrosoftEdge_*** and Microsoft.MicrosoftEdgeDevToolsClient_***
+      // see: https://docs.microsoft.com/en-us/windows/application-management/apps-in-windows-10
+      return  folder.indexOf('Microsoft.MicrosoftEdge_') === 0;
     }).map(function(folder) {
       return path.join(systemApps, folder);
     });

--- a/lib/local/platform/windows.js
+++ b/lib/local/platform/windows.js
@@ -99,7 +99,12 @@ function getEdgeDirectory() {
     var edgeFolders = fs.readdirSync(systemApps).filter(function(folder) {
       // Windows 10 has Microsoft.MicrosoftEdge_*** and Microsoft.MicrosoftEdgeDevToolsClient_***
       // see: https://docs.microsoft.com/en-us/windows/application-management/apps-in-windows-10
-      return  folder.indexOf('Microsoft.MicrosoftEdge_') === 0;
+      if (folder.indexOf("Microsoft.MicrosoftEdge") === 0) {
+        var edgePath = path.join(systemApps, folder, "MicrosoftEdge.exe");
+        if (fs.existsSync(edgePath)) {
+          return folder;
+        }
+      }
     }).map(function(folder) {
       return path.join(systemApps, folder);
     });


### PR DESCRIPTION
Some fixes for windows:
-  Chrome directory and edge directory
- Fix program files directory for x64 and x32 architectures, they were inverted:
```js
//Windows 64bits "Program Files"
//Windows 32bits "Program Files x86"
var programFiles = os.arch() === "x64" ? process.env.ProgramFiles : process.env["ProgramFiles(x86)"];
```

Fixes #96 