### PR TITLE
Fix clean option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,13 @@ matrix:
     - os: linux
       addons:
         firefox: latest
-        chrome: stable
+        apt:
+          packages:
+            - chromium-browser
     - os: osx
       osx_image: xcode10.1
+      addons:
+        chrome: stable
 
 
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,12 @@ language: node_js
 node_js: 
   - 8
 
-dist: trusty
-
 matrix:
   include:
     - os: linux
       addons:
         firefox: latest
-        apt:
-          packages:
-            - chromium-browser
+        chrome: stable
     - os: osx
       osx_image: xcode10.1
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,20 @@ language: node_js
 node_js: 
   - 8
 
+dist: xenial
+
+services:
+  - xvfb
 matrix:
   include:
     - os: linux
       addons:
         firefox: latest
-        apt:
-          packages:
-            - chromium-browser
+        chrome: stable
     - os: osx
       osx_image: xcode10.1
+      addons:
+        chrome: stable
+
 
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,20 +4,16 @@ language: node_js
 node_js: 
   - 8
 
-dist: xenial
+dist: trusty
 
-services:
-  - xvfb
-
-before_install:
-  - sudo apt-get update
-  - sudo apt-get -y install chromium-browser
-  
 matrix:
   include:
     - os: linux
       addons:
         firefox: latest
+        apt:
+          packages:
+            - chromium-browser
     - os: osx
       osx_image: xcode10.1
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ matrix:
         chrome: stable
     - os: osx
       osx_image: xcode10.1
-      addons:
-        chrome: stable
 
 
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ matrix:
         chrome: stable
     - os: osx
       osx_image: xcode10.1
-      addons:
-        chrome: stable
 
 
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,16 @@ dist: xenial
 
 services:
   - xvfb
+
+before_install:
+  - sudo apt-get update
+  - sudo apt-get -y install chromium-browser
+  
 matrix:
   include:
     - os: linux
       addons:
         firefox: latest
-        apt:
-          packages:
-            - chromium-browser
     - os: osx
       osx_image: xcode10.1
       addons:

--- a/examples/local.js
+++ b/examples/local.js
@@ -3,7 +3,7 @@ var launch = require('../lib');
 launch.local(function(err, launcher) {
 	// User the launcher api
 	launcher('http://github.com/ekryski', {
-		browser: 'safari'
+		browser: 'chrome'
 	}, function(error, worker) {
 		if(error) {
 			console.log('Error:', error);

--- a/examples/local.js
+++ b/examples/local.js
@@ -3,7 +3,7 @@ var launch = require('../lib');
 launch.local(function(err, launcher) {
 	// User the launcher api
 	launcher('http://github.com/ekryski', {
-		browser: 'chrome'
+		browser: 'safari'
 	}, function(error, worker) {
 		if(error) {
 			console.log('Error:', error);

--- a/examples/local.js
+++ b/examples/local.js
@@ -30,4 +30,22 @@ launch.local(function(err, launcher) {
 			});
 		}, 5000);
 	});
+
+	launcher.chrome('http://github.com/bitovi/launchpad', {
+		clean: true,
+		args: [
+			'--headless'
+		]
+	}, function(error, worker) {
+		if(error) {
+			console.log('Error:', error);
+			return;
+		}
+		console.log('Launched headless Chrome. Process id:', worker.id);
+		setTimeout(function() {
+			worker.stop(function() {
+				console.log('Chrome stopped');
+			});
+		}, 5000);
+	});
 });

--- a/lib/local/index.js
+++ b/lib/local/index.js
@@ -1,6 +1,9 @@
+var execSync = require('child_process').execSync;
+var join = require('path').join;
 var _ = require('underscore');
 var Q = require('q');
 var debug = require('debug')('launchpad:local');
+var mkdirp = require('mkdirp');
 
 var instance = require('./instance');
 var getBrowser = require('./browser');
@@ -11,11 +14,54 @@ var normalize = function(browser) {
   return _.pick(browser, 'name', 'version', 'path', 'binPath');
 };
 
-var tmpdir = process.env.TMPDIR || process.env.TMP;
+
+function makeNixTmpDir() {
+  return execSync('mktemp -d -t launchpad.tmp').toString().trim();
+}
+
+function makeWin32TmpDir() {
+  var winTmpPath = process.env.TEMP || process.env.TMP ||
+      (process.env.SystemRoot || process.env.windir) + '\\temp';
+  var randomNumber = Math.floor(Math.random() * 9e7 + 1e7);
+  var tmpdir = join(winTmpPath, 'launchpad.' + randomNumber);
+
+  mkdirp.sync(tmpdir);
+  return tmpdir;
+}
+
+var tmpdir = process.platform === "win32" ? makeWin32TmpDir() : makeNixTmpDir();
+
 var cleanLaunch = {
   firefox: ['-no-remote', '-silent', '-p', 'launchpad-firefox'],
   opera: ['-nosession'],
-  chrome: ['--no-default-browser-check', '--no-first-run', '--user-data-dir=' + tmpdir]
+  chrome: [
+      // Disable built-in Google Translate service
+    '--disable-features=TranslateUI',
+    // Disable all chrome extensions
+    '--disable-extensions',
+    // Disable some extensions that aren't affected by --disable-extensions
+    '--disable-component-extensions-with-background-pages',
+    // Disable various background network services, including extension updating,
+    //   safe browsing service, upgrade detector, translate, UMA
+    '--disable-background-networking',
+    // Disable syncing to a Google account
+    '--disable-sync',
+    // Disable reporting to UMA, but allows for collection
+    '--metrics-recording-only',
+    // Disable installation of default apps on first run
+    '--disable-default-apps',
+    // Mute any audio
+    '--mute-audio',
+    // Skip first run wizards
+    '--no-first-run',
+    // Disable backgrounding renders for occluded windows
+    '--disable-backgrounding-occluded-windows',
+    // Disable renderer process backgrounding
+    '--disable-renderer-backgrounding',
+    // Disable task throttling of timer tasks from background pages.
+    '--disable-background-timer-throttling',
+    '--user-data-dir=' + tmpdir
+  ]
 };
 
 module.exports = function (settings, callback) {
@@ -34,9 +80,27 @@ module.exports = function (settings, callback) {
         return Q.reject(new Error('Browser ' + name + ' not available.'));
       }
 
-      var args = browser.args || [];
-      if(options.clean && cleanLaunch[name]) {
-        args = args.concat(cleanLaunch[name]);
+      var args = [];
+      if(options.clean) {
+        if (cleanLaunch[name]) {
+          args = args.concat(cleanLaunch[name]);
+        }
+
+        //Clean instances needs to be run with bin file
+        browser.command = browser.binPath;
+
+        // keep the tmpdir in options
+        // in order to be cleaned after closing the browser
+        browser.tmpdir = tmpdir;
+        browser.clean = true;
+
+        // The settings to be passed to childProcess.spawn
+        // We need to have a detached clean process instance
+        settings = {
+          detached: true
+        };
+      } else {
+        args = browser.args;
       }
 
       if(options.args) {

--- a/lib/local/index.js
+++ b/lib/local/index.js
@@ -16,7 +16,7 @@ var normalize = function(browser) {
 
 
 function makeNixTmpDir() {
-  return execSync('mktemp -d -t launchpad.tmp').toString().trim();
+  return execSync('mktemp -d -t launchpad.XXXXXXX').toString().trim();
 }
 
 function makeWin32TmpDir() {

--- a/lib/local/instance.js
+++ b/lib/local/instance.js
@@ -3,6 +3,7 @@ var spawn = require("child_process").spawn;
 var exec = require("child_process").exec;
 var EventEmitter = require('events').EventEmitter;
 var debug = require('debug')('launchpad:local:instance');
+var rimraf = require('rimraf');
 
 var getProcessId = function (name, callback) {
 
@@ -28,6 +29,7 @@ var getProcessId = function (name, callback) {
 var Instance = function (cmd, args, settings, options) {
   this.options = options || {};
   var self = this;
+
   var childProcess = args === null ? exec(cmd, settings || {}) : spawn(cmd, args, settings || {});
 
   debug( (args === null ? 'exec' : 'spawn') + ' child process with process id',
@@ -81,20 +83,31 @@ Instance.prototype.stop = function (callback) {
       callback(null, data);
     });
   }
-
-  if (this.options.command.indexOf('open') === 0) {
-    command = 'osascript -e \'tell application "' + self.options.process + '" to quit\'';
-    debug('Executing shutdown AppleScript', command);
-    exec(command);
-  } else if (process.platform === 'win32') {
-    command = 'taskkill /IM ' + (this.options.imageName || path.basename(this.cmd));
-    debug('Executing shutdown taskkil', command);
-    exec(command).once('exit', function(data) {
-      self.emit('stop', data);
-    });
+  if (this.options.clean) {
+    try {
+      debug('Killing process', this.id);
+      process.kill(-this.id);
+    } catch (error) {}
   } else {
-    debug('Killing process', this.id);
-    this.process.kill();
+    if (this.options.command.indexOf('open') === 0) {
+      command = 'osascript -e \'tell application "' + self.options.process + '" to quit\'';
+      debug('Executing shutdown AppleScript', command);
+      exec(command);
+    } else if (process.platform === 'win32') {
+      command = 'taskkill /IM ' + (this.options.imageName || path.basename(this.cmd));
+      debug('Executing shutdown taskkil', command);
+      exec(command).once('exit', function(data) {
+        self.emit('stop', data);
+      });
+    } else {
+      debug('Killing process', this.id);
+      this.process.kill();
+    }
+  }
+
+  if (this.options.tmpdir) {
+    debug('Removing tmpdir', this.options.tmpdir);
+    rimraf(this.options.tmpdir, function() {});
   }
 };
 
@@ -126,7 +139,7 @@ exports.start = function (cmd, args, settings, options, callback) {
       var instance = getInstance();
 
       // Add a `running` flag if the browser is already running but can open a new tab
-      if(!err && options.opensTab) {
+      if(!err && options.opensTab && !options.clean) {
         debug('Marking instance as already running (but is able to open a tab)');
         instance.running = true;
       }

--- a/package.json
+++ b/package.json
@@ -54,8 +54,10 @@
     "async": "^2.0.1",
     "browserstack": "^1.2.0",
     "debug": "^2.2.0",
+    "mkdirp": "^0.5.1",
     "plist": "^2.0.1",
     "q": "^1.4.1",
+    "rimraf": "^3.0.0",
     "underscore": "^1.8.3"
   },
   "keywords": [

--- a/test/local.js
+++ b/test/local.js
@@ -123,48 +123,49 @@ describe('Local browser launcher tests', function() {
       });
     });
   });
-
-  describe('Clean option', function() {
-    var local = require('../lib/local');
-    var chrome;
-
-    function makeTest(isHeadless, done) {
-      local(function (error, launcher) {
-        var args = isHeadless ? ['--headless'] : [];
-        launcher.chrome('http://localhost:6785', {clean: true, args: args}, function(error, instance) {
-
-          if (error) return done(error);
-
-          server.once('request', function () {
-            assert.ok(instance.options.clean);
-            assert.ok(instance.options.tmpdir);
-            assert.notEqual(chrome.id, instance.id);
-            setTimeout(function () {
-              instance.stop(done());
-            }, 1000);
+  if (process.platform === 'linux') {
+    describe('Clean option', function() {
+      var local = require('../lib/local');
+      var chrome;
+  
+      function makeTest(isHeadless, done) {
+        local(function (error, launcher) {
+          var args = isHeadless ? ['--headless'] : [];
+          launcher.chrome('http://localhost:6785', {clean: true, args: args}, function(error, instance) {
+  
+            if (error) return done(error);
+  
+            server.once('request', function () {
+              assert.ok(instance.options.clean);
+              assert.ok(instance.options.tmpdir);
+              assert.notEqual(chrome.id, instance.id);
+              setTimeout(function () {
+                instance.stop(done());
+              }, 1000);
+            });
+          });
+        });
+      }
+  
+      beforeEach(function() {
+        local(function (error, launcher) {
+          launcher.chrome('http://localhost:6785', {clean: true}, function(error, instance) {
+            chrome = instance;
           });
         });
       });
-    }
-
-    beforeEach(function() {
-      local(function (error, launcher) {
-        launcher.chrome('http://localhost:6785', {clean: true}, function(error, instance) {
-          chrome = instance;
-        });
+  
+      afterEach(function() {
+        chrome.stop();
+      });
+  
+      it('Launches Chrome in clean mode', function(done) {
+        makeTest(false, done);
+      });
+  
+      it('Launches headless Chrome in clean mode', function(done) {
+        makeTest(true, done);
       });
     });
-
-    afterEach(function() {
-      chrome.stop();
-    });
-
-    it('Launches Chrome in clean mode', function(done) {
-      makeTest(false, done);
-    });
-
-    it('Launches headless Chrome in clean mode', function(done) {
-      makeTest(true, done);
-    });
-  });
+  }
 });

--- a/test/local.js
+++ b/test/local.js
@@ -125,7 +125,7 @@ describe('Local browser launcher tests', function() {
     });
   });
 
-  describe.only('Clean option', function() {
+  describe('Clean option', function() {
     var local = require('../lib/local');
     var chrome;
 

--- a/test/local.js
+++ b/test/local.js
@@ -46,7 +46,6 @@ describe('Local browser launcher tests', function() {
             server.once('request', function (req) {
               var userAgent = useragent.parse(req.headers['user-agent']);
               var expected = familyMapping[name] || name;
-              console.log(expected, userAgent.family.toLowerCase());
               assert.equal(userAgent.family.toLowerCase(), expected, 'Got expected browser family');
               instance.stop(done);
             });

--- a/test/local.js
+++ b/test/local.js
@@ -124,4 +124,48 @@ describe('Local browser launcher tests', function() {
       });
     });
   });
+
+  describe('Clean option', function() {
+    var local = require('../lib/local');
+    var chrome;
+
+    function makeTest(isHeadless, done) {
+      local(function (error, launcher) {
+        var args = isHeadless ? ['--headless'] : [];
+        launcher.chrome('http://localhost:6785', {clean: true, args: args}, function(error, instance) {
+
+          if (error) return done(error);
+
+          server.once('request', function () {
+            assert.ok(instance.options.clean);
+            assert.ok(instance.options.tmpdir);
+            assert.notEqual(chrome.id, instance.id);
+            setTimeout(function () {
+              instance.stop(done());
+            }, 1000);
+          });
+        });
+      });
+    }
+
+    beforeEach(function() {
+      local(function (error, launcher) {
+        launcher.chrome('http://localhost:6785', {clean: true}, function(error, instance) {
+          chrome = instance;
+        });
+      });
+    });
+
+    afterEach(function() {
+      chrome.stop();
+    });
+
+    it('Launches Chrome in clean mode', function(done) {
+      makeTest(false, done);
+    });
+
+    it('Launches headless Chrome in clean mode', function(done) {
+      makeTest(true, done);
+    });
+  });
 });

--- a/test/local.js
+++ b/test/local.js
@@ -46,7 +46,7 @@ describe('Local browser launcher tests', function() {
             server.once('request', function (req) {
               var userAgent = useragent.parse(req.headers['user-agent']);
               var expected = familyMapping[name] || name;
-
+              console.log(expected, userAgent.family.toLowerCase());
               assert.equal(userAgent.family.toLowerCase(), expected, 'Got expected browser family');
               instance.stop(done);
             });
@@ -125,7 +125,7 @@ describe('Local browser launcher tests', function() {
     });
   });
 
-  describe('Clean option', function() {
+  describe.only('Clean option', function() {
     var local = require('../lib/local');
     var chrome;
 


### PR DESCRIPTION
This fixes clean option for `Google Chrome` (headless/headful) browser by:

- Puts the right arguments for chrome to have a clean instance of the browser running.
- Detach the instance process so every running instance can be stopped separately.
- Every instance now has its own profile temporary directory.
- Remove the profile temporary directory after stopping the browser.

Fixes #118 