### PR TITLE
fix missing browser args

### DIFF
--- a/lib/local/index.js
+++ b/lib/local/index.js
@@ -99,7 +99,7 @@ module.exports = function (settings, callback) {
         settings = {
           detached: true
         };
-      } else {
+      } else if (browser.args) {
         args = browser.args;
       }
 


### PR DESCRIPTION
Closes #120 

This fixes the error when the browser args are not set, now it only sets the browsers arguments only when they are present. 